### PR TITLE
Feature - Scroll Restoration

### DIFF
--- a/meteor-app/imports/ui/app-root.jsx
+++ b/meteor-app/imports/ui/app-root.jsx
@@ -3,13 +3,16 @@ import PropTypes from "prop-types";
 import { ApolloProvider } from "react-apollo";
 import { BrowserRouter } from "react-router-dom";
 
+import ScrollRestoration from "./components/scroll-restoration";
 import Pages from "./pages";
 
 function AppRoot(props) {
 	return (
 		<ApolloProvider client={props.apolloClient}>
 			<BrowserRouter>
-				<Pages />
+				<ScrollRestoration>
+					<Pages />
+				</ScrollRestoration>
 			</BrowserRouter>
 		</ApolloProvider>
 	);

--- a/meteor-app/imports/ui/components/scroll-restoration/index.js
+++ b/meteor-app/imports/ui/components/scroll-restoration/index.js
@@ -1,0 +1,1 @@
+export default from "./scroll-restoration.jsx";

--- a/meteor-app/imports/ui/components/scroll-restoration/scroll-restoration.jsx
+++ b/meteor-app/imports/ui/components/scroll-restoration/scroll-restoration.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+// This component resets the scroll position to the top when ever the route is
+// changed. In the future this component should be enhanced to restore previous
+// scroll positions when going backward and forward through the history.
+class ScrollRestoration extends React.Component {
+	componentDidUpdate(prevProps) {
+		if (this.props.location.pathname !== prevProps.location.pathname) {
+			window.scrollTo(0, 0);
+		}
+	}
+
+	render() {
+		return this.props.children;
+	}
+}
+
+export default withRouter(ScrollRestoration);


### PR DESCRIPTION
Made a component that resets the scroll position to the top whenever the user opens a new page. This prevents the user from starting at the bottom of a page when they open it.

P.S. The component is called `ScrollRestoration` because in the future we should enhance it to also _restore_ previous scroll positions when the user goes back a page. For now it only resets the scroll.