### PR TITLE
Feature - npm ci

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,19 +19,15 @@ services:
         #       this sevice, try creating the directories
         #       `meteor-app/node_modules` and `meteor-app/.meteor/local`.
         #       It does not matter what is inside them, they just need to exist.
-        node-modules:/home/node/meteor/src/node_modules
-      - meteor-local:/home/node/meteor/src/.meteor/local
+        meteor-local:/home/node/meteor/src/.meteor/local
       - meteor-dotfile:/home/node/.meteor
 volumes:
   # Meteor build caches. Meteor and NPM download and create a lot of files.
   # We store this data in volumes so that is does not need to be redownloaded
   # and duplicated any more than nessisary.
 
-  # NPM's cache of dependencies.
-  ? node-modules
-
   # Meteor's cache of build artifacts. Allows for faster rebuilds.
-  ? meteor-local
+  meteor-local:
 
   # Meteor's dotfile where meteor is installed and caches its packages.
-  ? meteor-dotfile
+  meteor-dotfile:

--- a/meteor-app/Dockerfile-dev
+++ b/meteor-app/Dockerfile-dev
@@ -12,7 +12,6 @@ ENV APP_BUNDLE_DIR $APP_DIR/dist
 RUN mkdir -p \
 	$HOME/.meteor \
 	$APP_SOURCE_DIR \
-	$APP_SOURCE_DIR/node_modules \
 	$APP_SOURCE_DIR/.meteor/local
 
 COPY entrypoint-dev.sh $APP_SCRIPTS_DIR/

--- a/meteor-app/entrypoint-dev.sh
+++ b/meteor-app/entrypoint-dev.sh
@@ -20,4 +20,4 @@ export PATH="$HOME/.meteor:$PATH"
 
 meteor --version || install-meteor
 
-meteor npm install && meteor --no-lint --no-release-check
+meteor --no-lint --no-release-check

--- a/run.sh
+++ b/run.sh
@@ -7,10 +7,10 @@ case $1 in
 "i")
 	# Install/update the project's dependencies.
 	echo "Installing project root npm packages"
-	npm i
+	npm ci
 	cd meteor-app
 	echo "Installing meteor-app npm packages"
-	npm i
+	npm ci
 	echo "Generating code"
 	npm run gen
 	echo "Installing Meteor packages"


### PR DESCRIPTION
* Changed run.sh to use `npm ci` so that the `package-lock.json` files stop changing. 
* Changed the Docker dev testing system to not install NPM packages by itself. If some NPM install operation is needed use `./run.sh i` and restart the testing server.
* One of the Docker volumes, `node-modules`, is no longer needed. You can delete this from your computer to save a little disk space.