### PR TITLE
Bugfix - Allow introspection queries

### DIFF
--- a/meteor-app/imports/api/http/graphql-middleware.ts
+++ b/meteor-app/imports/api/http/graphql-middleware.ts
@@ -15,6 +15,7 @@ export function applyGraphQLMiddleware(app: Express) {
 			// switching away from Meteor's authorization framework.
 			user: await getUser(req.headers.authorization),
 		}),
+		introspection: true,
 	});
 
 	apolloServer.applyMiddleware({


### PR DESCRIPTION
Allow introspection queries on the production servers so that we can use tools like [Prisma's GraphQL Playground](https://github.com/prisma/graphql-playground/) to test things out.