### PR TITLE
Bugfix - Meteor's gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ config
 # NPM stuff
 node_modules
 
-# Meteor stuff
-meteor-app/.meteor/local
+# Meteor stuff - Meteor automatically generates its own gitignore.
+meteor-app/.meteor/.gitignore
 
 # Mac stuff
 ._*


### PR DESCRIPTION
Fixed git ignore rules because Meteor generates its own `.gitignore` file when run.