### PR TITLE
solved the problem with company URL 

### DIFF
--- a/meteor-app/imports/ui/pages/company-profile/summary.jsx
+++ b/meteor-app/imports/ui/pages/company-profile/summary.jsx
@@ -58,12 +58,13 @@ function CompanyProfileSummary(props) {
 							</p>
 							<p>
 								<FontAwesomeIcon icon={faGlobe} />{" "}
-								<Link
-									to={props.company.websiteURL || ""}
+								<a
+									href={props.company.websiteURL}
 									target="_blank"
+									rel="noopener noreferrer"
 								>
 									{props.company.websiteURL}
-								</Link>
+								</a>
 							</p>
 							<p>
 								<FontAwesomeIcon icon={faUsers} />{" "}


### PR DESCRIPTION
update company link to open the actual URL in a new page with no threats from _blank

<Link> is only used for internal routing 
next time you need to work with eternal routing use 
the usual <a href="...">

https://github.com/ReactTraining/react-router/issues/1147#issuecomment-113180174 

also, don't forget to add  rel="noopener noreferrer"  to fix the _blank vulnerability
https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/