### PR TITLE
Save users' emails

### DIFF
--- a/meteor-app/imports/ui/pages/register/register-form.tsx
+++ b/meteor-app/imports/ui/pages/register/register-form.tsx
@@ -71,6 +71,7 @@ const onSubmit = history => (values, actions) => {
 	};
 	const options = {
 		username: values.username,
+		email: values.email,
 		password: values.password,
 		role: values.role,
 	};


### PR DESCRIPTION
Fixed register form not sending the users' email addresses to the server.

The server is already setup to save the emails if they are sent. I believe we were thinking that emails should be optional and that is why this was never looked at before. We would benefit from being more clear in our technical requirements.

The server does not require that emails be sent. In the new auth system we should make emails required if we want to have them.