### PR TITLE
Add salary form to review form

### DIFF
--- a/meteor-app/imports/api/graphql/resolvers/mutation.ts
+++ b/meteor-app/imports/api/graphql/resolvers/mutation.ts
@@ -37,7 +37,6 @@ export const Mutation: MutationResolvers = {
 	},
 
 	createReview: async (_obj, { input }, context, _info) => {
-		console.log("whatinput", input);
 		if (!context.user) throw new Error("NOT_LOGGED_IN");
 
 		const reviewId = await dataModel.createReview(
@@ -46,7 +45,6 @@ export const Mutation: MutationResolvers = {
 		);
 
 		const review = await dataModel.getReviewById(reviewId);
-
 		return { review };
 	},
 

--- a/meteor-app/imports/api/graphql/resolvers/mutation.ts
+++ b/meteor-app/imports/api/graphql/resolvers/mutation.ts
@@ -36,12 +36,7 @@ export const Mutation: MutationResolvers = {
 		return { company };
 	},
 
-	createReview: async (
-		_obj,
-		{ input: { incomeType, gender, incomeAmount, ...input } },
-		context,
-		_info
-	) => {
+	createReview: async (_obj, { input }, context, _info) => {
 		console.log("whatinput", input);
 		if (!context.user) throw new Error("NOT_LOGGED_IN");
 
@@ -50,31 +45,9 @@ export const Mutation: MutationResolvers = {
 			await dataModel.getUserPostgresId(context.user._id)
 		);
 
-		const salaryId = await dataModel.createSalary(
-			{
-				// TODO: change the database so that we do not need to convert these.
-				incomeAmount: incomeAmount,
-				incomeType:
-					incomeType === "YEARLY_SALARY"
-						? "Yearly Salary"
-						: incomeType === "MONTHLY_SALARY"
-						? "Monthly Salary"
-						: "Hourly Wage",
-				gender:
-					gender === "MALE"
-						? "Male"
-						: gender === "FEMALE"
-						? "Female"
-						: undefined,
-				...input,
-			},
-			await dataModel.getUserPostgresId(context.user._id)
-		);
-
 		const review = await dataModel.getReviewById(reviewId);
-		const salary = await dataModel.getSalaryById(salaryId);
 
-		return { review, salary };
+		return { review };
 	},
 
 	createSalary: async (

--- a/meteor-app/imports/api/graphql/resolvers/mutation.ts
+++ b/meteor-app/imports/api/graphql/resolvers/mutation.ts
@@ -36,14 +36,45 @@ export const Mutation: MutationResolvers = {
 		return { company };
 	},
 
-	createReview: async (_obj, { input }, context, _info) => {
+	createReview: async (
+		_obj,
+		{ input: { incomeType, gender, incomeAmount, ...input } },
+		context,
+		_info
+	) => {
+		console.log("whatinput", input);
 		if (!context.user) throw new Error("NOT_LOGGED_IN");
+
 		const reviewId = await dataModel.createReview(
 			input,
 			await dataModel.getUserPostgresId(context.user._id)
 		);
+
+		const salaryId = await dataModel.createSalary(
+			{
+				// TODO: change the database so that we do not need to convert these.
+				incomeAmount: incomeAmount,
+				incomeType:
+					incomeType === "YEARLY_SALARY"
+						? "Yearly Salary"
+						: incomeType === "MONTHLY_SALARY"
+						? "Monthly Salary"
+						: "Hourly Wage",
+				gender:
+					gender === "MALE"
+						? "Male"
+						: gender === "FEMALE"
+						? "Female"
+						: undefined,
+				...input,
+			},
+			await dataModel.getUserPostgresId(context.user._id)
+		);
+
 		const review = await dataModel.getReviewById(reviewId);
-		return { review };
+		const salary = await dataModel.getSalaryById(salaryId);
+
+		return { review, salary };
 	},
 
 	createSalary: async (

--- a/meteor-app/imports/api/graphql/schema.graphql
+++ b/meteor-app/imports/api/graphql/schema.graphql
@@ -76,7 +76,6 @@ input CreateReviewInput {
 
 type CreateReviewPayload {
 	review: Review
-	salary: Salary
 }
 
 input CreateSalaryInput {

--- a/meteor-app/imports/api/graphql/schema.graphql
+++ b/meteor-app/imports/api/graphql/schema.graphql
@@ -72,6 +72,8 @@ input CreateReviewInput {
 	benefits: Int!
 	overallSatisfaction: Int!
 	additionalComments: String
+	incomeType: String!
+	incomeAmount: String!
 }
 
 type CreateReviewPayload {

--- a/meteor-app/imports/api/graphql/schema.graphql
+++ b/meteor-app/imports/api/graphql/schema.graphql
@@ -72,12 +72,11 @@ input CreateReviewInput {
 	benefits: Int!
 	overallSatisfaction: Int!
 	additionalComments: String
-	incomeType: String!
-	incomeAmount: String!
 }
 
 type CreateReviewPayload {
 	review: Review
+	salary: Salary
 }
 
 input CreateSalaryInput {

--- a/meteor-app/imports/ui/components/button/write-review-button.tsx
+++ b/meteor-app/imports/ui/components/button/write-review-button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
-import ReactGA from 'react-ga';
+import ReactGA from "react-ga";
 
 import { urlGenerators } from "imports/ui/pages/url-generators";
 import { LinkButton } from "imports/ui/components/button";
@@ -14,17 +14,20 @@ interface WriteReviewButtonProps {
 }
 
 function buttonTracking(buttonLocation) {
-	console.log("triggered")
 	ReactGA.event({
-	  category: 'Button',
-	  action: 'Add Review Pressed',
-	  label: buttonLocation
+		category: "Button",
+		action: "Add Review Pressed",
+		label: buttonLocation,
 	});
 }
 
 function WriteReviewButton(props: WriteReviewButtonProps) {
 	return (
-		<LinkButton to={urlGenerators.vizeReviewUrl(props.companyName)} onClick={ () => buttonTracking(props.buttonLocation) } primary>
+		<LinkButton
+			to={urlGenerators.vizeReviewUrl(props.companyName)}
+			onClick={() => buttonTracking(props.buttonLocation)}
+			primary
+		>
 			<FontAwesomeIcon icon={faPlus} />
 			&nbsp;
 			<T.add_review />

--- a/meteor-app/imports/ui/pages/company-profile/company-profile.tsx
+++ b/meteor-app/imports/ui/pages/company-profile/company-profile.tsx
@@ -40,7 +40,7 @@ function CompanyProfile_(props) {
 								<li
 									className="active"
 									role="presentation"
-									style={{ width: "25%" }}
+									style={{ width: "33%" }}
 								>
 									<Link
 										to="#overview"
@@ -53,7 +53,7 @@ function CompanyProfile_(props) {
 								</li>
 								<li
 									role="presentation"
-									style={{ width: "25%" }}
+									style={{ width: "33%" }}
 								>
 									<Link
 										to="#reviews"
@@ -66,7 +66,7 @@ function CompanyProfile_(props) {
 								</li>
 								<li
 									role="presentation"
-									style={{ width: "25%" }}
+									style={{ width: "33%" }}
 								>
 									<Link
 										to="#jobs"
@@ -77,10 +77,12 @@ function CompanyProfile_(props) {
 										<T.companyprofile.jobs />
 									</Link>
 								</li>
+								{/*
 								<li
 									role="presentation"
 									style={{ width: "25%" }}
 								>
+
 									<Link
 										to="#salaries"
 										aria-controls="salaries"
@@ -90,6 +92,7 @@ function CompanyProfile_(props) {
 										<T.companyprofile.salaries />
 									</Link>
 								</li>
+								*/}
 								{/* Commenting out the Contact Us form for now */}
 								{/* <li role="presentation"><Link to="#contact" aria-controls="contact" role="tab" data-toggle="tab">Contact</Link></li> */}
 							</ul>

--- a/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
@@ -41,6 +41,8 @@ const initialValues = {
 	benefits: "",
 	overallSatisfaction: "",
 	additionalComments: "",
+	incomeType: "",
+	incomeAmount: "",
 };
 
 const proConSchema = yup
@@ -97,16 +99,33 @@ const schema = yup.object().shape({
 	benefits: starRatingSchema,
 	overallSatisfaction: starRatingSchema,
 	additionalComments: yup.string(),
+	incomeType: yup
+		.string()
+		.oneOf([
+			"YEARLY_SALARY",
+			"MONTHLY_SALARY",
+			"WEEKLY_SALARY",
+			"DAILY_SALARY",
+			"HOURLY_WAGE",
+		])
+		.required("Se requiere el tipo de ingreso"),
+	incomeAmount: yup
+		.number()
+		.min(0)
+		.required("Se requiere la cantidad de ingresos"),
 });
 
 function CreateReviewForm({ history, companyName, user }) {
 	const [submissionError, setSubmissionError] = React.useState(null);
 	let [content, setContent] = React.useState(null);
 
-	const onSubmit = (createReview, history, setSubmissionError) => (
-		values,
-		actions
-	) => {
+	const onSubmit = (
+		createReview,
+		createSalary,
+		history,
+		setSubmissionError
+	) => (values, actions) => {
+		console.log(values);
 		createReview({
 			variables: {
 				input: omitEmptyStrings(values),
@@ -114,6 +133,46 @@ function CreateReviewForm({ history, companyName, user }) {
 		})
 			.then(({ data }) => {
 				console.log("data", data);
+
+				createSalary({
+					variables: {
+						input: omitEmptyStrings(values),
+					},
+				})
+					.then(({ data }) => {
+						console.log("data", data);
+
+						actions.resetForm(initialValues);
+
+						// Go to the review submitted page so that the user can claim their reward.
+						history.push("/review-submitted");
+					})
+					.catch(errors => {
+						console.error(errors.message);
+						if (errors.message === "GraphQL error: NOT_LOGGED_IN") {
+							setContent(
+								<PopupModal isOpen={true}>
+									<RegisterLoginModal />
+								</PopupModal>
+							);
+						} else {
+							//if (errors.nessage);
+							console.log(mapValues(errors, x => x));
+
+							// cut out the "GraphQL error: " from error message
+							const errorMessage = errors.message.substring(14);
+
+							setSubmissionError(errorMessage);
+
+							// Errors to display on form fields
+							const formErrors = {};
+
+							// TODO: better error displaying.
+
+							actions.setErrors(formErrors);
+						}
+						actions.setSubmitting(false);
+					});
 
 				actions.resetForm(initialValues);
 
@@ -155,7 +214,7 @@ function CreateReviewForm({ history, companyName, user }) {
 	return (
 		<div>
 			<MutationCreateReview>
-				{createReview => (
+				{(createReview, createSalary) => (
 					<Formik
 						initialValues={merge(initialValues, {
 							companyName,
@@ -163,6 +222,7 @@ function CreateReviewForm({ history, companyName, user }) {
 						validationSchema={schema}
 						onSubmit={onSubmit(
 							createReview,
+							createSalary,
 							history,
 							setSubmissionError
 						)}

--- a/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
@@ -117,6 +117,7 @@ const schema = yup.object().shape({
 });
 
 // TODO: Check if user has already added a salary so that there is no error in submitting a review
+// You would just need to write a query to see if the user has written a salary already and if so only call the createReview mutation
 function CreateReviewForm({ history, companyName, user }) {
 	const [submissionError, setSubmissionError] = React.useState(null);
 	let [content, setContent] = React.useState(null);

--- a/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
@@ -166,7 +166,6 @@ function CreateReviewForm({ history, companyName, user }) {
 		createReview({
 			variables: {
 				reviewInput: omitEmptyStrings(reviewValues),
-				salaryInput: omitEmptyStrings(salaryValues),
 			},
 		})
 			.then(({ data }) => {

--- a/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
@@ -116,6 +116,7 @@ const schema = yup.object().shape({
 		.required("Se requiere la cantidad de ingresos"),
 });
 
+// TODO: Check if user has already added a salary so that there is no error in submitting a review
 function CreateReviewForm({ history, companyName, user }) {
 	const [submissionError, setSubmissionError] = React.useState(null);
 	let [content, setContent] = React.useState(null);
@@ -124,8 +125,6 @@ function CreateReviewForm({ history, companyName, user }) {
 		values,
 		actions
 	) => {
-		console.log(values);
-
 		const reviewValues = {
 			companyName: values.companyName,
 			reviewTitle: values.reviewTitle,
@@ -160,8 +159,6 @@ function CreateReviewForm({ history, companyName, user }) {
 			},
 			gender: values.location.gender,
 		};
-		console.log("salaryValues", salaryValues);
-		console.log("reviewValues", reviewValues);
 
 		createReview({
 			variables: {
@@ -170,8 +167,6 @@ function CreateReviewForm({ history, companyName, user }) {
 			},
 		})
 			.then(({ data }) => {
-				console.log("data", data);
-
 				actions.resetForm(initialValues);
 
 				// Go to the review submitted page so that the user can claim their reward.

--- a/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
@@ -43,6 +43,7 @@ const initialValues = {
 	additionalComments: "",
 	incomeType: "",
 	incomeAmount: "",
+	gender: "",
 };
 
 const proConSchema = yup
@@ -119,60 +120,57 @@ function CreateReviewForm({ history, companyName, user }) {
 	const [submissionError, setSubmissionError] = React.useState(null);
 	let [content, setContent] = React.useState(null);
 
-	const onSubmit = (
-		createReview,
-		createSalary,
-		history,
-		setSubmissionError
-	) => (values, actions) => {
+	const onSubmit = (createReview, history, setSubmissionError) => (
+		values,
+		actions
+	) => {
 		console.log(values);
+
+		const reviewValues = {
+			companyName: values.companyName,
+			reviewTitle: values.reviewTitle,
+			location: {
+				city: values.location.city,
+				address: values.location.address,
+				industrialHub: values.location.industrialHub,
+			},
+			jobTitle: values.jobTitle,
+			numberOfMonthsWorked: values.numberOfMonthsWorked,
+			pros: values.pros,
+			cons: values.cons,
+			wouldRecommendToOtherJobSeekers:
+				values.wouldRecommendToOtherJobSeekers,
+			healthAndSafety: values.healthAndSafety,
+			managerRelationship: values.managerRelationship,
+			workEnvironment: values.workEnvironment,
+			benefits: values.benefits,
+			overallSatisfaction: values.overallSatisfaction,
+			additionalComments: values.additionalComments,
+		};
+
+		const salaryValues = {
+			companyName: values.companyName,
+			jobTitle: values.jobTitle,
+			incomeAmount: values.incomeAmount,
+			incomeType: values.incomeType,
+			location: {
+				city: values.location.city,
+				address: values.location.address,
+				industrialHub: values.location.industrialHub,
+			},
+			gender: values.location.gender,
+		};
+		console.log("salaryValues", salaryValues);
+		console.log("reviewValues", reviewValues);
+
 		createReview({
 			variables: {
-				input: omitEmptyStrings(values),
+				reviewInput: omitEmptyStrings(reviewValues),
+				salaryInput: omitEmptyStrings(salaryValues),
 			},
 		})
 			.then(({ data }) => {
 				console.log("data", data);
-
-				createSalary({
-					variables: {
-						input: omitEmptyStrings(values),
-					},
-				})
-					.then(({ data }) => {
-						console.log("data", data);
-
-						actions.resetForm(initialValues);
-
-						// Go to the review submitted page so that the user can claim their reward.
-						history.push("/review-submitted");
-					})
-					.catch(errors => {
-						console.error(errors.message);
-						if (errors.message === "GraphQL error: NOT_LOGGED_IN") {
-							setContent(
-								<PopupModal isOpen={true}>
-									<RegisterLoginModal />
-								</PopupModal>
-							);
-						} else {
-							//if (errors.nessage);
-							console.log(mapValues(errors, x => x));
-
-							// cut out the "GraphQL error: " from error message
-							const errorMessage = errors.message.substring(14);
-
-							setSubmissionError(errorMessage);
-
-							// Errors to display on form fields
-							const formErrors = {};
-
-							// TODO: better error displaying.
-
-							actions.setErrors(formErrors);
-						}
-						actions.setSubmitting(false);
-					});
 
 				actions.resetForm(initialValues);
 
@@ -214,7 +212,7 @@ function CreateReviewForm({ history, companyName, user }) {
 	return (
 		<div>
 			<MutationCreateReview>
-				{(createReview, createSalary) => (
+				{createReview => (
 					<Formik
 						initialValues={merge(initialValues, {
 							companyName,
@@ -222,7 +220,6 @@ function CreateReviewForm({ history, companyName, user }) {
 						validationSchema={schema}
 						onSubmit={onSubmit(
 							createReview,
-							createSalary,
 							history,
 							setSubmissionError
 						)}

--- a/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-form.tsx
@@ -166,6 +166,7 @@ function CreateReviewForm({ history, companyName, user }) {
 		createReview({
 			variables: {
 				reviewInput: omitEmptyStrings(reviewValues),
+				salaryInput: omitEmptyStrings(salaryValues),
 			},
 		})
 			.then(({ data }) => {

--- a/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
@@ -116,6 +116,23 @@ function InnerForm({ submissionError }) {
 				t={T.fields.additionalComments}
 			/>
 
+			<T.fields.incomeType
+				renderer={t => (
+					<Field name="incomeType" select required label="lbl">
+						<option value="YEARLY_SALARY">yearly</option>
+						<option value="MONTHLY_SALARY">monthly</option>
+						<option value="HOURLY_WAGE">hourly</option>
+					</Field>
+				)}
+			/>
+
+			<Field
+				name="incomeAmount"
+				type="number"
+				required
+				t={T.fields.incomeAmount}
+			/>
+
 			<SubmissionError error={submissionError} />
 
 			<FormToolbar>

--- a/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
@@ -118,10 +118,14 @@ function InnerForm({ submissionError }) {
 
 			<T.fields.incomeType
 				renderer={t => (
-					<Field name="incomeType" select required label="lbl">
-						<option value="YEARLY_SALARY">yearly</option>
-						<option value="MONTHLY_SALARY">monthly</option>
-						<option value="HOURLY_WAGE">hourly</option>
+					<Field name="incomeType" select required label={t.label}>
+						<option value="YEARLY_SALARY">{t.yearlySalary}</option>
+						<option value="MONTHLY_SALARY">
+							{t.monthlySalary}
+						</option>
+						<option value="WEEKLY_SALARY">{t.weeklySalary}</option>
+						<option value="DAILY_SALARY">{t.dailySalary}</option>
+						<option value="HOURLY_WAGE">{t.hourlyWage}</option>
 					</Field>
 				)}
 			/>

--- a/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
@@ -31,6 +31,7 @@ function InnerForm({ submissionError }) {
 			<Field
 				name="location.city"
 				type="text"
+				variant="privacyTextField"
 				required
 				t={T.fields.location.city}
 			/>
@@ -118,7 +119,13 @@ function InnerForm({ submissionError }) {
 
 			<T.fields.incomeType
 				renderer={t => (
-					<Field name="incomeType" select required label={t.label}>
+					<Field
+						name="incomeType"
+						select
+						variant="privacyTextField"
+						required
+						label={t.label}
+					>
 						<option value="YEARLY_SALARY">{t.yearlySalary}</option>
 						<option value="MONTHLY_SALARY">
 							{t.monthlySalary}
@@ -133,6 +140,7 @@ function InnerForm({ submissionError }) {
 			<Field
 				name="incomeAmount"
 				type="number"
+				variant="privacyTextField"
 				required
 				t={T.fields.incomeAmount}
 			/>

--- a/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
@@ -7,6 +7,7 @@ import {
 	Field,
 	FormToolbar,
 	SubmissionError,
+	FormText,
 } from "imports/ui/components/form-stuff";
 import { translations } from "imports/ui/translations";
 
@@ -125,6 +126,9 @@ function InnerForm({ submissionError }) {
 			/>
 
 			<FormDividerLine />
+			<FormText>
+				<T.formSalaryNotice />
+			</FormText>
 
 			<T.fields.incomeType
 				renderer={t => (

--- a/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
+++ b/meteor-app/imports/ui/pages/create-review/create-review-inner-form.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Form } from "formik";
 import { SubmitButton } from "imports/ui/components/button";
+import styled from "styled-components";
 
 import {
 	Field,
@@ -10,6 +11,12 @@ import {
 import { translations } from "imports/ui/translations";
 
 const T = translations.createReview;
+
+const FormDividerLine = styled.hr`
+	border: 1px solid black;
+	margin-left: -30px;
+	margin-right: -30px;
+`;
 
 function InnerForm({ submissionError }) {
 	return (
@@ -116,6 +123,8 @@ function InnerForm({ submissionError }) {
 				rows={6}
 				t={T.fields.additionalComments}
 			/>
+
+			<FormDividerLine />
 
 			<T.fields.incomeType
 				renderer={t => (

--- a/meteor-app/imports/ui/pages/create-review/create-review.graphql
+++ b/meteor-app/imports/ui/pages/create-review/create-review.graphql
@@ -1,5 +1,8 @@
-mutation createReview($input: CreateReviewInput!) {
-	createReview(input: $input) {
+mutation createReview(
+	$reviewInput: CreateReviewInput!
+	$salaryInput: CreateSalaryInput!
+) {
+	createReview(input: $reviewInput) {
 		review {
 			id
 			company {
@@ -25,7 +28,7 @@ mutation createReview($input: CreateReviewInput!) {
 			}
 		}
 	}
-	createSalary(input: $input) {
+	createSalary(input: $salaryInput) {
 		salary {
 			id
 			company {

--- a/meteor-app/imports/ui/pages/create-review/create-review.graphql
+++ b/meteor-app/imports/ui/pages/create-review/create-review.graphql
@@ -25,4 +25,21 @@ mutation createReview($input: CreateReviewInput!) {
 			}
 		}
 	}
+	createSalary(input: $input) {
+		salary {
+			id
+			company {
+				name
+			}
+			jobTitle
+			location {
+				address
+				city
+				industrialHub
+			}
+			incomeType
+			incomeAmount
+			created
+		}
+	}
 }

--- a/meteor-app/imports/ui/pages/create-review/create-review.graphql
+++ b/meteor-app/imports/ui/pages/create-review/create-review.graphql
@@ -1,7 +1,4 @@
-mutation createReview(
-	$reviewInput: CreateReviewInput!
-	$salaryInput: CreateSalaryInput!
-) {
+mutation createReview($reviewInput: CreateReviewInput!) {
 	createReview(input: $reviewInput) {
 		review {
 			id
@@ -26,23 +23,6 @@ mutation createReview(
 			currentUserVote {
 				isUpvote
 			}
-		}
-	}
-	createSalary(input: $salaryInput) {
-		salary {
-			id
-			company {
-				name
-			}
-			jobTitle
-			location {
-				address
-				city
-				industrialHub
-			}
-			incomeType
-			incomeAmount
-			created
 		}
 	}
 }

--- a/meteor-app/imports/ui/pages/create-review/create-review.graphql
+++ b/meteor-app/imports/ui/pages/create-review/create-review.graphql
@@ -1,4 +1,7 @@
-mutation createReview($reviewInput: CreateReviewInput!) {
+mutation createReview(
+	$reviewInput: CreateReviewInput!
+	$salaryInput: CreateSalaryInput!
+) {
 	createReview(input: $reviewInput) {
 		review {
 			id
@@ -23,6 +26,23 @@ mutation createReview($reviewInput: CreateReviewInput!) {
 			currentUserVote {
 				isUpvote
 			}
+		}
+	}
+	createSalary(input: $salaryInput) {
+		salary {
+			id
+			company {
+				name
+			}
+			jobTitle
+			location {
+				address
+				city
+				industrialHub
+			}
+			incomeType
+			incomeAmount
+			created
 		}
 	}
 }

--- a/meteor-app/imports/ui/translations/en.tsx
+++ b/meteor-app/imports/ui/translations/en.tsx
@@ -219,6 +219,7 @@ export default {
 				yearlySalary: "Yearly Salary",
 				monthlySalary: "Monthly Salary",
 				weeklySalary: "Weekly Salary",
+				dailySalary: "Daily Salary",
 				hourlyWage: "Hourly Wage",
 			},
 			incomeAmount: {

--- a/meteor-app/imports/ui/translations/en.tsx
+++ b/meteor-app/imports/ui/translations/en.tsx
@@ -146,6 +146,8 @@ export default {
 		formSubTitle2: "Claim your $100 pesos with Swap or Paypal.",
 		formSubTitle3:
 			" Privacy Notice: Your identity will be hidden to make this review anonymous. Your username and any fields that have a shield icon will not be displayed in your review.",
+		formSalaryNotice:
+			"Salary data will not be displayed in this review. To protect your identity, this data will be aggregated with other salaries to create a summary.",
 		fields: {
 			companyName: {
 				label: "Company Name",

--- a/meteor-app/imports/ui/translations/en.tsx
+++ b/meteor-app/imports/ui/translations/en.tsx
@@ -214,6 +214,16 @@ export default {
 				placeholder:
 					"Enter any additional thoughts or comments you may have on your experience working for this company.",
 			},
+			incomeType: {
+				label: "Income Type (in Pesos)",
+				yearlySalary: "Yearly Salary",
+				monthlySalary: "Monthly Salary",
+				weeklySalary: "Weekly Salary",
+				hourlyWage: "Hourly Wage",
+			},
+			incomeAmount: {
+				label: "Income Amount",
+			},
 		},
 		submit: "Submit",
 	},

--- a/meteor-app/imports/ui/translations/es.tsx
+++ b/meteor-app/imports/ui/translations/es.tsx
@@ -155,6 +155,8 @@ export default {
 		formSubTitle2: "Reclama tus $100 pesos con Swap o Paypal.",
 		formSubTitle3:
 			" Aviso de Privacidad: Su identidad se ocultará para que esta evaluación sea anónima. Su nombre de usuario y los campos que tengan un icono de escudo no se mostrarán en su evaluación.",
+		formSalaryNotice:
+			"Los datos salariales no se mostrarán en esta evaluación. Para proteger su identidad, estos datos se van a agregar con otros salarios para crear un resumen.",
 		fields: {
 			companyName: {
 				label: "Nombre de la empresa",

--- a/meteor-app/imports/ui/translations/es.tsx
+++ b/meteor-app/imports/ui/translations/es.tsx
@@ -224,6 +224,17 @@ export default {
 				placeholder:
 					"Ingrese cualquier pensamiento o comentario adicional que pueda tener sobre su experiencia trabajando para esta empresa.",
 			},
+			incomeType: {
+				label: "Tipo de Ingreso (en Pesos)",
+				yearlySalary: "Anual",
+				monthlySalary: "Mensual",
+				weeklySalary: "Sueldo por Semana",
+				dailySalary: "Sueldo por Día",
+				hourlyWage: "Sueldo por Hora",
+			},
+			incomeAmount: {
+				label: "Cantidad de Ingresos",
+			},
 		},
 		submit: "Enviar",
 	},


### PR DESCRIPTION
- Changed GraphQL mutation so that creating a review calls the createReview and createSalary resolvers and therefore creates two separate reviews from the same form.
- Front end changes to the form to add the two salary fields and includes privacy text
- Removed salary from company profile because it is currently not a finished product and is not private because each salary is posted separately instead of as a summary.
- Cleaned up some console logs
- Learned a lot of GraphQL :D
