### PR TITLE
Fixed race hazard in `createUser`

### DIFF
--- a/meteor-app/imports/api/connectors/postgresql.ts
+++ b/meteor-app/imports/api/connectors/postgresql.ts
@@ -4,7 +4,7 @@
 import { Pool, PoolClient, QueryConfig } from "pg";
 
 /** The connection pool for the PostgreSQL database. */
-const pool = new Pool();
+export const pool = new Pool();
 
 // Transactions are functions that take a database connection and use it to run
 // queries on the database. If any extra arguments are needed by the

--- a/meteor-app/imports/api/http/passport-middleware.ts
+++ b/meteor-app/imports/api/http/passport-middleware.ts
@@ -31,10 +31,7 @@ export function applyPassportMiddleware(app: Express) {
 
 	app.post("/login", async function(req, res, next) {
 		try {
-			const user = await verifyUser({
-				username: req.body.username,
-				password: req.body.password,
-			});
+			const user = await verifyUser(req.body);
 
 			req.logIn(user, function(err) {
 				if (err) {
@@ -70,12 +67,7 @@ export function applyPassportMiddleware(app: Express) {
 
 	app.post("/register", async function(req, res, next) {
 		try {
-			const user = await createUser({
-				username: req.body.username,
-				email: req.body.email,
-				password: req.body.password,
-				role: req.body.role,
-			});
+			const user = await createUser(req.body);
 
 			// Automatically log the new user in.
 			req.logIn(user, function(err) {
@@ -103,11 +95,7 @@ export function applyPassportMiddleware(app: Express) {
 
 	app.post("/change-password", async function(req, res, next) {
 		try {
-			await changePassword(
-				req.user,
-				req.body.oldPassword,
-				req.body.newPassword
-			);
+			await changePassword(req.user, req.body);
 		} catch (e) {
 			if (e instanceof yup.ValidationError) {
 				res.status(401).json({ errors: e.errors });

--- a/meteor-app/imports/api/models/mutations/user.ts
+++ b/meteor-app/imports/api/models/mutations/user.ts
@@ -1,11 +1,7 @@
 import * as yup from "yup";
 
 import sql from "imports/lib/sql-template";
-import {
-	Transaction,
-	execTransactionRW,
-	simpleQuery,
-} from "imports/api/connectors/postgresql";
+import { pool } from "imports/api/connectors/postgresql";
 import {
 	User,
 	getUserByUsername,
@@ -16,69 +12,44 @@ import { postToSlack } from "imports/api/connectors/slack-webhook";
 
 import { attributes } from "../queries/user";
 
-type CreateUserInput = {
-	username: string;
-	email: string;
-	password: string;
-	role: "worker" | "company";
-};
+const createUserInputSchema = yup.object({
+	username: yup
+		.string()
+		.trim()
+		.min(1)
+		.max(32)
+		.required(),
+	email: yup
+		.string()
+		.email()
+		.required(),
+	password: yup
+		.string()
+		.min(1)
+		.max(256)
+		.required(),
+	role: yup
+		.mixed<"worker" | "company">()
+		.oneOf(["worker", "company"])
+		.required(),
+});
 
-namespace CreateUserInput {
-	export const schema = yup.object({
-		username: yup
-			.string()
-			.trim()
-			.min(1)
-			.max(32)
-			.required(),
-		email: yup
-			.string()
-			.email()
-			.required(),
-		password: yup
-			.string()
-			.min(1)
-			.max(256)
-			.required(),
-		role: yup
-			.mixed<"worker" | "company">()
-			.oneOf(["worker", "company"])
-			.required(),
-	});
-}
-
-export async function createUser(input: CreateUserInput): Promise<User> {
+export async function createUser(input: unknown): Promise<User> {
 	const {
 		username,
 		email,
 		password,
 		role,
-	} = await CreateUserInput.schema.validate(input, {
+	} = await createUserInputSchema.validate(input, {
 		abortEarly: false,
 	});
 
-	const transaction: Transaction<User> = async client => {
-		if (
-			(await client.query(
-				sql`SELECT userid FROM users WHERE username=${username}`
-			)).rows.length > 0
-		) {
-			throw "username is taken";
-		}
+	const passwordHash = await hashPassword(password);
 
-		if (
-			(await client.query(
-				sql`SELECT userid FROM users WHERE email_address=${email}`
-			)).rows.length > 0
-		) {
-			throw "email is taken";
-		}
-
-		const passwordHash = await hashPassword(password);
-
+	try {
 		const {
 			rows: [user],
-		} = await client.query(sql`
+		} = await pool.query(sql`
 			INSERT INTO users 
 				(username, email_address, password_hash, role) 
 			VALUES 
@@ -91,33 +62,31 @@ export async function createUser(input: CreateUserInput): Promise<User> {
 		);
 
 		return user;
-	};
-
-	return execTransactionRW(transaction);
-}
-
-type VerifyUserInput = {
-	username: string;
-	password: string;
-};
-
-namespace VerifyUserInput {
-	export const schema = yup.object({
-		username: yup
-			.string()
-			.trim()
-			.required(),
-		password: yup.string().required(),
-	});
-}
-
-export async function verifyUser(input: VerifyUserInput): Promise<User> {
-	const { username, password } = await VerifyUserInput.schema.validate(
-		input,
-		{
-			abortEarly: false,
+	} catch (err) {
+		if (err.constraint === "users_username_key") {
+			throw `That username is already taken. Please choose a different one.`;
 		}
-	);
+
+		if (err.constraint === "users_email_address_key") {
+			throw `That email address is used by another account. Please use a different one.`;
+		}
+
+		throw err;
+	}
+}
+
+const verifyUserInputSchema = yup.object({
+	username: yup
+		.string()
+		.trim()
+		.required(),
+	password: yup.string().required(),
+});
+
+export async function verifyUser(input: unknown): Promise<User> {
+	const { username, password } = await verifyUserInputSchema.validate(input, {
+		abortEarly: false,
+	});
 
 	const user = await getUserByUsername(username);
 
@@ -134,11 +103,22 @@ export async function verifyUser(input: VerifyUserInput): Promise<User> {
 	return user;
 }
 
+const changePasswordInputSchema = yup.object({
+	oldPassword: yup.string().required(),
+	newPassword: yup.string().required(),
+});
+
 export async function changePassword(
 	user: User | undefined | null,
-	oldPassword: string,
-	newPassword: string
+	input: unknown
 ) {
+	const {
+		oldPassword,
+		newPassword,
+	} = await changePasswordInputSchema.validate(input, {
+		abortEarly: false,
+	});
+
 	if (!user) {
 		throw "You must be logged in to change your password.";
 	}
@@ -151,7 +131,7 @@ export async function changePassword(
 
 	const newPasswordHash = await hashPassword(newPassword);
 
-	await simpleQuery(sql`
+	await pool.query(sql`
 		UPDATE users
 		SET password_hash = ${newPasswordHash}
 		WHERE username = ${user.username}

--- a/postgres/migrations/V1.13__fix_missing_constraints_on_users.sql
+++ b/postgres/migrations/V1.13__fix_missing_constraints_on_users.sql
@@ -1,0 +1,7 @@
+
+-- The username is a natural key for users.
+ALTER TABLE users ADD CONSTRAINT users_username_key UNIQUE (username);
+ALTER TABLE users ALTER COLUMN username SET NOT NULL;
+
+-- If users are allowed to login with their email address it must be unique.
+ALTER TABLE users ADD CONSTRAINT users_email_address_key UNIQUE (email_address);


### PR DESCRIPTION
Fixed a race hazard in the `createUser` model. If created at the same time users could have the same username and/or email address as each other. This is fixed by moving constraint checking to the database and not checking it manually.

Similar issues may exist for the other mutations.