### PR TITLE
Fix URLs for Facebook login

### DIFF
--- a/meteor-app/imports/api/http/passport-middleware.ts
+++ b/meteor-app/imports/api/http/passport-middleware.ts
@@ -119,7 +119,7 @@ export function applyPassportMiddleware(app: Express) {
 				{
 					clientID: process.env.FACEBOOK_APP_ID,
 					clientSecret: process.env.FACEBOOK_APP_SECRET,
-					callbackURL: `${process.env.ROOT_URL}/auth/facebook/callback`,
+					callbackURL: `${process.env.ROOT_URL}/api/auth/facebook/callback`,
 				},
 				async function(accessToken, refreshToken, profile, cb) {
 					try {

--- a/meteor-app/imports/ui/components/login-with-facebook.tsx
+++ b/meteor-app/imports/ui/components/login-with-facebook.tsx
@@ -7,7 +7,7 @@ const X = styled.div`
 
 const LoginWithFacebook: React.FC = () => (
 	<X>
-		or <a href="/auth/facebook">Login with Facebook</a>
+		or <a href="/api/auth/facebook">Login with Facebook</a>
 	</X>
 );
 


### PR DESCRIPTION
Fixed the URLs for the Facebook login. This is needed because the API server's resources were moved under `/api`.