### PR TITLE
Removed uses of React.FC and React.ComponentType

### DIFF
--- a/web-app/src/components/button/add-salary-button.tsx
+++ b/web-app/src/components/button/add-salary-button.tsx
@@ -22,7 +22,9 @@ function buttonTracking(buttonLocation?: string) {
 	});
 }
 
-function AddSalaryButton(props: AddSalaryButtonProps) {
+export default function AddSalaryButton(
+	props: AddSalaryButtonProps
+): JSX.Element {
 	return (
 		<LinkButton
 			to={urlGenerators.vizeSalaryUrl(props.companyName)}
@@ -35,8 +37,3 @@ function AddSalaryButton(props: AddSalaryButtonProps) {
 		</LinkButton>
 	);
 }
-
-// Work around until we get types on withUpdateOnChangeLocale.
-const foo: React.ComponentType<AddSalaryButtonProps> = AddSalaryButton;
-
-export default foo;

--- a/web-app/src/components/button/write-review-button.tsx
+++ b/web-app/src/components/button/write-review-button.tsx
@@ -22,7 +22,9 @@ function buttonTracking(buttonLocation?: string) {
 	});
 }
 
-function WriteReviewButton(props: WriteReviewButtonProps) {
+export default function WriteReviewButton(
+	props: WriteReviewButtonProps
+): JSX.Element {
 	return (
 		<LinkButton
 			to={urlGenerators.vizeReviewUrl(props.companyName)}
@@ -35,8 +37,3 @@ function WriteReviewButton(props: WriteReviewButtonProps) {
 		</LinkButton>
 	);
 }
-
-// Work around until we get types on withUpdateOnChangeLocale.
-const foo: React.ComponentType<WriteReviewButtonProps> = WriteReviewButton;
-
-export default foo;

--- a/web-app/src/components/form-stuff/field/field.tsx
+++ b/web-app/src/components/form-stuff/field/field.tsx
@@ -12,11 +12,7 @@ const FormikField = styled(Formik.Field)`
 	margin-top: 10px !important;
 `;
 
-const FieldInner: React.ComponentType<any> = ({
-	type,
-	variant,
-	...restProps
-}) => {
+function FieldInner({ type, variant, ...restProps }: any): JSX.Element {
 	if (type === "rating") {
 		return <Formik.Field {...restProps} component={RatingField} />;
 	}
@@ -49,9 +45,9 @@ const FieldInner: React.ComponentType<any> = ({
 			fullWidth
 		/>
 	);
-};
+}
 
-const FieldComponent: React.ComponentType<any> = ({ t: T, ...restProps }) => {
+function FieldComponent({ t: T, ...restProps }: any): JSX.Element {
 	if (T !== undefined) {
 		return (
 			<T renderer={(t: any) => <FieldInner {...restProps} {...t} />} />
@@ -59,7 +55,7 @@ const FieldComponent: React.ComponentType<any> = ({ t: T, ...restProps }) => {
 	}
 
 	return FieldInner(restProps);
-};
+}
 
 // Added this margin so that error messages do not overlap with other fields
 const Field = styled(FieldComponent)`

--- a/web-app/src/components/form-stuff/field/radio-buttons-field.tsx
+++ b/web-app/src/components/form-stuff/field/radio-buttons-field.tsx
@@ -7,14 +7,14 @@ import FormControl from "@material-ui/core/FormControl";
 import FormLabel from "@material-ui/core/FormLabel";
 import PrivacyIcon from "@material-ui/icons/Security";
 
-const RadioButtonsField: React.FC<any> = ({
+export default function RadioButtonsField({
 	field,
 	form: { touched, errors },
 	name,
 	options,
 	label,
 	...props
-}) => {
+}: any): JSX.Element {
 	const [value, setValue] = React.useState("FORMER");
 
 	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,6 +40,4 @@ const RadioButtonsField: React.FC<any> = ({
 			</RadioGroup>
 		</FormControl>
 	);
-};
-
-export default RadioButtonsField;
+}

--- a/web-app/src/components/header/lang-selector.tsx
+++ b/web-app/src/components/header/lang-selector.tsx
@@ -12,12 +12,14 @@ interface LocaleIconProps {
 	code: keyof (typeof localeMetadata);
 }
 
-const LocaleIcon: React.FC<LocaleIconProps> = ({ code }) => (
-	<img
-		src={localeMetadata[code].icon}
-		alt={localeMetadata[code].nativeName}
-	/>
-);
+function LocaleIcon({ code }: LocaleIconProps): JSX.Element {
+	return (
+		<img
+			src={localeMetadata[code].icon}
+			alt={localeMetadata[code].nativeName}
+		/>
+	);
+}
 
 const LocaleButton = styled.button`
 	padding: 0;
@@ -48,7 +50,7 @@ const langOptions = (setLocale: (locale: string) => void) => (
 	</>
 );
 
-function LangSelector() {
+export default function LangSelector(): JSX.Element {
 	const locale = React.useContext(LocaleContext);
 	const setLocale = React.useContext(LocaleSetterContext);
 
@@ -68,5 +70,3 @@ function LangSelector() {
 		</Popup>
 	);
 }
-
-export default LangSelector;

--- a/web-app/src/components/login-with-facebook.tsx
+++ b/web-app/src/components/login-with-facebook.tsx
@@ -5,10 +5,10 @@ const X = styled.div`
 	text-align: center;
 `;
 
-const LoginWithFacebook: React.FC = () => (
-	<X>
-		or <a href="/api/auth/facebook">Login with Facebook</a>
-	</X>
-);
-
-export default LoginWithFacebook;
+export default function LoginWithFacebook(): JSX.Element {
+	return (
+		<X>
+			or <a href="/api/auth/facebook">Login with Facebook</a>
+		</X>
+	);
+}


### PR DESCRIPTION
Removed all uses of `React.FC` and `React.ComponentType` for typing components because they are not exactly correct and it's easier to just use normal type annotation on the component functions.

A line like `const MyComponent: React.FC<MyComponentProps> = (props) => {` is practically the same as `function MyComponent(props: MyComponentProps): JSX.Element {`.